### PR TITLE
Bugfix: cron timers not initialized during boot.

### DIFF
--- a/src/timer.c
+++ b/src/timer.c
@@ -521,7 +521,7 @@ void USER_FUNC timer_init(void)
 					"timer", 512, state, HFTHREAD_PRIORITIES_LOW, NULL, NULL) != HF_SUCCESS) {
 		u_printf("timer thread create failed!\n");
 	}
-	
+	parse_crontab();
 	httpd_add_page("/timer", httpd_page_timer, NULL);
 	httpd_add_page("/ntp", httpd_page_ntp, NULL);
 }


### PR DESCRIPTION
During boot even if cron settings are saved - timers won't be initialized and next start (Next action:) will always be set to 01.01.1900 00:00.
Need to run parse_crontab() during timer thread start.